### PR TITLE
Pin lerna to 8.2.4 and upgrade base image to node:20-alpine (3.0.13)

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -41,9 +41,6 @@ jobs:
 
           echo "version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -58,6 +55,8 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          # amd64 only: CircleCI executors are amd64 and the arm64 build
+          # SIGILLs under QEMU emulation with node:20 (illegal instruction)
+          platforms: linux/amd64
           push: true
           tags: ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-from node:16-alpine3.13 as builder
+from node:20-alpine as builder
 
 workdir /home/circletron/app
 copy package.json package-lock.json ./
@@ -6,8 +6,8 @@ run npm install
 copy src ./src
 run npm run build
 
-from node:16-alpine3.13
-run apk add git openssh-client && npm install -g lerna
+from node:20-alpine
+run apk add git openssh-client && npm install -g lerna@8.2.4
 copy --from=builder /home/circletron/app /home/circletron/app
 run \
   ln -s /home/circletron/app /usr/local/lib/node_modules/circletron && \

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,13 @@
 # Changelog
 
-- 2026/07/28 - 3.1.0
+- 2026/07/29 - 3.0.13
+
+  - Pin `lerna` to 8.2.4 in the Docker image. The unpinned `npm install -g lerna`
+    started pulling lerna 9, which requires Node 18+ and crashes on the image's
+    Node 16 base, breaking the `trigger-jobs` setup job.
+  - Upgrade the Docker base image from `node:16-alpine3.13` to `node:20-alpine`.
+
+- 2026/07/28 - 3.0.12
 
   - Add opt-in `skip: check-runs` mode: skipped workflows are omitted from the generated configuration entirely and the setup job posts a GitHub check run per skipped workflow, named like the required check with conclusion `skipped`, so branch protection stays satisfied without running any skip jobs. Workflows whose check run cannot be posted fall back to the green `skip` workflow.
   - Add `checkNames` option to map workflow names to required check names.

--- a/orb.yml
+++ b/orb.yml
@@ -6,7 +6,7 @@ description: >
 executors:
   circletron-executor:
     docker:
-      - image: circletron/circletron:3.1.0
+      - image: ghcr.io/empathycom/circletron:3.0.13
 
 jobs:
   trigger-jobs:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "circletron",
-  "version": "3.1.0",
+  "version": "3.0.13",
   "description": "circle orb for dealing with monorepos",
   "author": "insidewhy <github@chilon.net>",
   "license": "ISC",


### PR DESCRIPTION
## Problem
The `3.0.12` Docker image broke the `trigger-jobs` setup job in consumers (e.g. empathy-monorepo PR #18721 → https://github.com/empathycom/empathy-monorepo/pull/18721).

The Dockerfile installs an unpinned global `lerna`. Rebuilding the image for 3.0.12 pulled **lerna 9.0.7**, which requires Node 18+, while the base image is Node 16. `lerna list` crashes at startup loading `lru-cache`:

```
TypeError: (0 , U.tracingChannel) is not a function
    at /usr/local/lib/node_modules/lerna/node_modules/lru-cache/dist/commonjs/node/index.min.js:1
```

The working `3.0.11` image shipped lerna **8.2.4** on the same Node 16 base.

## Fix
- Pin `lerna` to `8.2.4` (the exact version in the working 3.0.11 image) so generated config behaviour stays identical.
- Upgrade base image `node:16-alpine3.13` → `node:20-alpine`.
- Publish workflow now builds **linux/amd64 only**: the arm64 build runs under QEMU emulation and SIGILLs with node:20 (`qemu: uncaught target signal 4`). CircleCI executors — the image's only consumer — are amd64, matching every previously published image.
- Bump version to `3.0.13`, update changelog and orb executor image.

## Validation
- `npm run validate-prettiness` passes.
- Built the image locally (linux/amd64) and ran `lerna list --parseable --all --long` against a pnpm/lerna fixture:
  - `ghcr.io/empathycom/circletron:3.0.12` → crashes with the error above
  - this branch's image → succeeds (lerna 8.2.4 lists all packages)
- Tag `3.0.13` published `ghcr.io/empathycom/circletron:3.0.13` via the GHCR workflow; empathy-monorepo PR #18721 validated against it.

---
Conversation: https://app.warp.dev/conversation/a5db2c46-de94-4a00-b4d7-a5a24904cd91

Co-Authored-By: Oz <oz-agent@warp.dev>