### PR TITLE
Fall back to commit statuses for skipped-workflow reporting (3.0.14)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+- 2026/07/29 - 3.0.14
+
+  - In `skip: check-runs` mode, when posting the `skipped` check run fails
+    (e.g. the token is a personal access token, which cannot use the Checks
+    API), fall back to posting a classic commit status with state `success`
+    under the same required-check context before degrading to a skip
+    workflow. Requires branch protection checks that accept any source.
+
 - 2026/07/29 - 3.0.13
 
   - Pin `lerna` to 8.2.4 in the Docker image. The unpinned `npm install -g lerna`

--- a/orb.yml
+++ b/orb.yml
@@ -6,7 +6,7 @@ description: >
 executors:
   circletron-executor:
     docker:
-      - image: ghcr.io/empathycom/circletron:3.0.13
+      - image: ghcr.io/empathycom/circletron:3.0.14
 
 jobs:
   trigger-jobs:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "circletron",
-  "version": "3.0.13",
+  "version": "3.0.14",
   "description": "circle orb for dealing with monorepos",
   "author": "insidewhy <github@chilon.net>",
   "license": "ISC",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
   GITHUB_CHECKS_TOKEN_VAR,
   getCheckRunTarget,
   postSkippedCheckRun,
+  postSkippedCommitStatus,
   runReportSkipCli,
   writeSkipsArtifact,
 } from './report-skip'
@@ -356,14 +357,15 @@ export async function triggerCiJobs(
       fallbackWorkflows = new Set(skippedWorkflows)
     } else {
       const results = await Promise.all(
-        skippedWorkflows.map(async (workflow) => ({
-          workflow,
-          posted: await postSkippedCheckRun(
-            target,
-            circletronConfig.checkNames[workflow] ?? workflow,
-            workflow,
-          ),
-        })),
+        skippedWorkflows.map(async (workflow) => {
+          const checkName = circletronConfig.checkNames[workflow] ?? workflow
+          // tokens without Checks API access (e.g. personal access tokens)
+          // fall back to a classic commit status under the same context
+          const posted =
+            (await postSkippedCheckRun(target, checkName, workflow)) ||
+            (await postSkippedCommitStatus(target, checkName, workflow))
+          return { workflow, posted }
+        }),
       )
       fallbackWorkflows = new Set(results.filter((r) => !r.posted).map((r) => r.workflow))
     }

--- a/src/report-skip.spec.ts
+++ b/src/report-skip.spec.ts
@@ -8,6 +8,7 @@ import {
   buildSkipArtifact,
   getCheckRunTarget,
   postSkippedCheckRun,
+  postSkippedCommitStatus,
   reportSkip,
   writeSkipsArtifact,
 } from './report-skip'
@@ -108,6 +109,51 @@ describe('postSkippedCheckRun', () => {
       await expect(postSkippedCheckRun(target, 'my-workflow', 'my-workflow')).resolves.toBe(false)
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining("failed to create check run 'my-workflow'"),
+      )
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+})
+
+describe('postSkippedCommitStatus', () => {
+  const target = { owner: 'empathycom', repo: 'circletron', headSha: 'abc123', token: 'gh-token' }
+
+  beforeEach(() => {
+    mockedAxios.post.mockReset()
+    mockedAxios.post.mockResolvedValue({ data: {} })
+  })
+
+  it('posts a successful commit status under the exact required check context', async () => {
+    await expect(
+      postSkippedCommitStatus(target, 'ci/circleci: my-workflow', 'my-workflow'),
+    ).resolves.toBe(true)
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      'https://api.github.com/repos/empathycom/circletron/statuses/abc123',
+      {
+        state: 'success',
+        context: 'ci/circleci: my-workflow',
+        description: 'Skipped by circletron: workflow my-workflow unaffected',
+      },
+      {
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: 'Bearer gh-token',
+        },
+      },
+    )
+  })
+
+  it('returns false and warns when the request fails', async () => {
+    mockedAxios.post.mockRejectedValue(new Error('boom'))
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
+    try {
+      await expect(postSkippedCommitStatus(target, 'my-workflow', 'my-workflow')).resolves.toBe(
+        false,
+      )
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("failed to create commit status 'my-workflow'"),
       )
     } finally {
       warnSpy.mockRestore()

--- a/src/report-skip.ts
+++ b/src/report-skip.ts
@@ -66,6 +66,44 @@ async function postCheckRun(target: CheckRunTarget, payload: CheckRunPayload): P
 }
 
 /**
+ * Fallback for tokens that cannot use the Checks API (e.g. personal access
+ * tokens): post a classic commit status under the required check's context.
+ * Statuses have no `skipped` state so it reports `success` with a
+ * description marking the skip.
+ */
+export async function postSkippedCommitStatus(
+  target: CheckRunTarget,
+  checkName: string,
+  workflow: string,
+): Promise<boolean> {
+  try {
+    await axios.post(
+      `${GITHUB_API_URL}/repos/${target.owner}/${target.repo}/statuses/${target.headSha}`,
+      {
+        state: 'success',
+        context: checkName,
+        description: `Skipped by circletron: workflow ${workflow} unaffected`.slice(0, 140),
+      },
+      {
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: `Bearer ${target.token}`,
+        },
+      },
+    )
+    console.log(`Created skipped commit status '${checkName}'`)
+    return true
+  } catch (e) {
+    console.warn(
+      `Warning: failed to create commit status '${checkName}': ${
+        e instanceof Error ? e.message : String(e)
+      }`,
+    )
+    return false
+  }
+}
+
+/**
  * Unlike buildCheckRunPayload the name must exactly match the required check
  * it stands in for: branch protection accepts a `skipped` conclusion as
  * passing, so no skip workflow has to run at all.


### PR DESCRIPTION
## What
In `skip: check-runs` mode, when posting the `skipped` check run fails, circletron now falls back to posting a **classic commit status** (`state: success`) under the same required-check context, before degrading to the green skip workflow.

## Why
Validating `check-runs` mode on empathy-monorepo hit two real-world constraints:
- The Checks API requires a GitHub App token; personal access tokens get `403 Resource not accessible` (the org's fine-grained PATs cannot even grant `Checks`).
- Commit statuses satisfy branch-protection required checks just like check runs (required checks on `main` were unpinned from the CircleCI app to allow this).

Degradation chain in check-runs mode: `skipped` check run (App token) → `success` commit status with "Skipped by circletron" description (PAT with repo:status) → green skip workflow (no token). Queue reduction (zero workflow runs) holds for the first two.

## Validation
- `npm run validate` green (20 tests, new specs for `postSkippedCommitStatus`).
- Image built and smoke-tested (lerna 8.2.4, new dist verified); pushed as `ghcr.io/empathycom/circletron:3.0.14`.
- End-to-end validation on empathy-monorepo PR #18721 (https://github.com/empathycom/empathy-monorepo/pull/18721).

---
Conversation: https://app.warp.dev/conversation/a5db2c46-de94-4a00-b4d7-a5a24904cd91

Co-Authored-By: Oz <oz-agent@warp.dev>