### PR TITLE
Mint GitHub App installation tokens for skipped check runs (3.0.15)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+- 2026/07/29 - 3.0.15
+
+  - Mint a GitHub App installation token when `GITHUB_CHECKS_APP_ID` and
+    `GITHUB_CHECKS_APP_PRIVATE_KEY` are set (and `GITHUB_CHECKS_TOKEN` is
+    not), so skipped workflows are reported as proper check runs with
+    conclusion `skipped`. The private key may be provided as a raw PEM or
+    base64-encoded.
+
 - 2026/07/29 - 3.0.14
 
   - In `skip: check-runs` mode, when posting the `skipped` check run fails

--- a/orb.yml
+++ b/orb.yml
@@ -6,7 +6,7 @@ description: >
 executors:
   circletron-executor:
     docker:
-      - image: ghcr.io/empathycom/circletron:3.0.14
+      - image: ghcr.io/empathycom/circletron:3.0.15
 
 jobs:
   trigger-jobs:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "circletron",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "circle orb for dealing with monorepos",
   "author": "insidewhy <github@chilon.net>",
   "license": "ISC",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,10 +11,12 @@ import { requireEnv } from './env'
 import { getBranchpointCommitAndTargetBranch } from './git'
 import { spawnGetStdout } from './command'
 import {
+  GITHUB_CHECKS_APP_ID_VAR,
+  GITHUB_CHECKS_APP_PRIVATE_KEY_VAR,
   GITHUB_CHECKS_TOKEN_VAR,
-  getCheckRunTarget,
   postSkippedCheckRun,
   postSkippedCommitStatus,
+  resolveCheckRunTarget,
   runReportSkipCli,
   writeSkipsArtifact,
 } from './report-skip'
@@ -348,11 +350,12 @@ export async function triggerCiJobs(
 
   let fallbackWorkflows = new Set<string>()
   if (circletronConfig.skip === 'check-runs' && skippedWorkflows.length > 0) {
-    const target = getCheckRunTarget()
+    const target = await resolveCheckRunTarget()
     if (!target) {
       console.warn(
-        `Warning: ${GITHUB_CHECKS_TOKEN_VAR} or the CircleCI project environment variables ` +
-          'are not set, falling back to skip workflows',
+        `Warning: no GitHub credentials (${GITHUB_CHECKS_TOKEN_VAR}, or ` +
+          `${GITHUB_CHECKS_APP_ID_VAR} with ${GITHUB_CHECKS_APP_PRIVATE_KEY_VAR}) or the ` +
+          'CircleCI project environment variables are not set, falling back to skip workflows',
       )
       fallbackWorkflows = new Set(skippedWorkflows)
     } else {

--- a/src/report-skip.spec.ts
+++ b/src/report-skip.spec.ts
@@ -1,15 +1,19 @@
+import { createVerify, generateKeyPairSync } from 'crypto'
 import { readFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import axios from 'axios'
 
 import {
+  buildAppJwt,
   buildCheckRunPayload,
   buildSkipArtifact,
   getCheckRunTarget,
+  mintAppInstallationToken,
   postSkippedCheckRun,
   postSkippedCommitStatus,
   reportSkip,
+  resolveCheckRunTarget,
   writeSkipsArtifact,
 } from './report-skip'
 
@@ -113,6 +117,130 @@ describe('postSkippedCheckRun', () => {
     } finally {
       warnSpy.mockRestore()
     }
+  })
+})
+
+const testKeyPair = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+})
+
+const fromBase64url = (part: string): Buffer =>
+  Buffer.from(part.replace(/-/g, '+').replace(/_/g, '/'), 'base64')
+
+describe('buildAppJwt', () => {
+  it('builds a valid RS256 JWT identifying the app', () => {
+    const jwt = buildAppJwt('12345', testKeyPair.privateKey, 1_700_000_000)
+    const [header, payload, signature] = jwt.split('.')
+
+    expect(JSON.parse(fromBase64url(header).toString())).toEqual({ alg: 'RS256', typ: 'JWT' })
+    expect(JSON.parse(fromBase64url(payload).toString())).toEqual({
+      iat: 1_700_000_000 - 60,
+      exp: 1_700_000_000 + 540,
+      iss: '12345',
+    })
+    expect(
+      createVerify('RSA-SHA256')
+        .update(`${header}.${payload}`)
+        .verify(testKeyPair.publicKey, fromBase64url(signature)),
+    ).toBe(true)
+  })
+
+  it('accepts a base64-encoded private key', () => {
+    const encoded = Buffer.from(testKeyPair.privateKey).toString('base64')
+    expect(buildAppJwt('12345', encoded)).toEqual(expect.stringMatching(/^[\w-]+\.[\w-]+\./))
+  })
+})
+
+describe('mintAppInstallationToken', () => {
+  const appEnv = {
+    GITHUB_CHECKS_APP_ID: '12345',
+    GITHUB_CHECKS_APP_PRIVATE_KEY: testKeyPair.privateKey,
+  }
+
+  beforeEach(() => {
+    mockedAxios.get.mockReset()
+    mockedAxios.post.mockReset()
+  })
+
+  it('resolves the repo installation and mints an access token', async () => {
+    mockedAxios.get.mockResolvedValue({ data: { id: 99 } })
+    mockedAxios.post.mockResolvedValue({ data: { token: 'installation-token' } })
+
+    await expect(mintAppInstallationToken('empathycom', 'circletron', appEnv)).resolves.toEqual(
+      'installation-token',
+    )
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      'https://api.github.com/repos/empathycom/circletron/installation',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: expect.stringMatching(/^Bearer /) }),
+      }),
+    )
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      'https://api.github.com/app/installations/99/access_tokens',
+      {},
+      expect.anything(),
+    )
+  })
+
+  it('returns undefined when the app credentials are not configured', async () => {
+    await expect(
+      mintAppInstallationToken('empathycom', 'circletron', {}),
+    ).resolves.toBeUndefined()
+    expect(mockedAxios.get).not.toHaveBeenCalled()
+  })
+
+  it('returns undefined and warns when minting fails', async () => {
+    mockedAxios.get.mockRejectedValue(new Error('boom'))
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
+    try {
+      await expect(
+        mintAppInstallationToken('empathycom', 'circletron', appEnv),
+      ).resolves.toBeUndefined()
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('failed to mint GitHub App installation token'),
+      )
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+})
+
+describe('resolveCheckRunTarget', () => {
+  beforeEach(() => {
+    mockedAxios.get.mockReset()
+    mockedAxios.post.mockReset()
+  })
+
+  it('prefers an explicit GITHUB_CHECKS_TOKEN', async () => {
+    await expect(
+      resolveCheckRunTarget({ ...testEnv, GITHUB_CHECKS_TOKEN: 'gh-token' }),
+    ).resolves.toEqual({
+      owner: 'empathycom',
+      repo: 'circletron',
+      headSha: 'abc123',
+      token: 'gh-token',
+    })
+    expect(mockedAxios.get).not.toHaveBeenCalled()
+  })
+
+  it('mints an installation token from the app credentials', async () => {
+    mockedAxios.get.mockResolvedValue({ data: { id: 99 } })
+    mockedAxios.post.mockResolvedValue({ data: { token: 'installation-token' } })
+
+    await expect(
+      resolveCheckRunTarget({
+        ...testEnv,
+        GITHUB_CHECKS_APP_ID: '12345',
+        GITHUB_CHECKS_APP_PRIVATE_KEY: testKeyPair.privateKey,
+      }),
+    ).resolves.toEqual(expect.objectContaining({ token: 'installation-token' }))
+  })
+
+  it('resolves undefined without credentials', async () => {
+    await expect(resolveCheckRunTarget(testEnv)).resolves.toBeUndefined()
   })
 })
 

--- a/src/report-skip.ts
+++ b/src/report-skip.ts
@@ -1,3 +1,4 @@
+import { createSign } from 'crypto'
 import { mkdir, writeFile } from 'fs'
 import { promisify } from 'util'
 import { dirname } from 'path'
@@ -9,6 +10,8 @@ const pWriteFile = promisify(writeFile)
 const GITHUB_API_URL = 'https://api.github.com'
 
 export const GITHUB_CHECKS_TOKEN_VAR = 'GITHUB_CHECKS_TOKEN'
+export const GITHUB_CHECKS_APP_ID_VAR = 'GITHUB_CHECKS_APP_ID'
+export const GITHUB_CHECKS_APP_PRIVATE_KEY_VAR = 'GITHUB_CHECKS_APP_PRIVATE_KEY'
 export const DEFAULT_SKIP_ARTIFACT_PATH = '/tmp/circletron/skip.json'
 export const DEFAULT_SKIPS_ARTIFACT_PATH = '/tmp/circletron/skips.json'
 
@@ -51,6 +54,99 @@ export function getCheckRunTarget(
   const repo = env.CIRCLE_PROJECT_REPONAME
   const headSha = env.CIRCLE_SHA1
   if (!token || !owner || !repo || !headSha) {
+    return undefined
+  }
+  return { owner, repo, headSha, token }
+}
+
+const base64url = (data: string | Buffer): string =>
+  Buffer.from(data).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+
+/**
+ * The private key may be provided as a raw PEM (possibly with `\n` escape
+ * sequences instead of newlines) or base64-encoded.
+ */
+const normalizePrivateKey = (key: string): string => {
+  if (key.includes('-----BEGIN')) {
+    return key.replace(/\\n/g, '\n')
+  }
+  return Buffer.from(key, 'base64').toString()
+}
+
+/** Build a short-lived RS256 JWT identifying the GitHub App. */
+export function buildAppJwt(
+  appId: string,
+  privateKey: string,
+  nowSeconds: number = Math.floor(Date.now() / 1000),
+): string {
+  const header = base64url(JSON.stringify({ alg: 'RS256', typ: 'JWT' }))
+  // 60s clock-drift allowance, 9 minute lifetime (GitHub's maximum is 10)
+  const payload = base64url(
+    JSON.stringify({ iat: nowSeconds - 60, exp: nowSeconds + 540, iss: appId }),
+  )
+  const signature = createSign('RSA-SHA256')
+    .update(`${header}.${payload}`)
+    .sign(normalizePrivateKey(privateKey))
+  return `${header}.${payload}.${base64url(signature)}`
+}
+
+/**
+ * Mint a GitHub App installation token from the app id and private key
+ * environment variables. Returns undefined when they are not configured or
+ * the token cannot be minted.
+ */
+export async function mintAppInstallationToken(
+  owner: string,
+  repo: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<string | undefined> {
+  const appId = env[GITHUB_CHECKS_APP_ID_VAR]
+  const privateKey = env[GITHUB_CHECKS_APP_PRIVATE_KEY_VAR]
+  if (!appId || !privateKey) {
+    return undefined
+  }
+
+  try {
+    const headers = {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${buildAppJwt(appId, privateKey)}`,
+    }
+    const installation = await axios.get<{ id: number }>(
+      `${GITHUB_API_URL}/repos/${owner}/${repo}/installation`,
+      { headers },
+    )
+    const accessToken = await axios.post<{ token: string }>(
+      `${GITHUB_API_URL}/app/installations/${installation.data.id}/access_tokens`,
+      {},
+      { headers },
+    )
+    console.log(`Minted GitHub App installation token for ${owner}/${repo}`)
+    return accessToken.data.token
+  } catch (e) {
+    console.warn(
+      `Warning: failed to mint GitHub App installation token: ${
+        e instanceof Error ? e.message : String(e)
+      }`,
+    )
+    return undefined
+  }
+}
+
+/**
+ * Resolve the check run target: an explicit GITHUB_CHECKS_TOKEN wins,
+ * otherwise a token is minted from the GitHub App credentials.
+ */
+export async function resolveCheckRunTarget(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<CheckRunTarget | undefined> {
+  const owner = env.CIRCLE_PROJECT_USERNAME
+  const repo = env.CIRCLE_PROJECT_REPONAME
+  const headSha = env.CIRCLE_SHA1
+  if (!owner || !repo || !headSha) {
+    return undefined
+  }
+  const token = env[GITHUB_CHECKS_TOKEN_VAR] ?? (await mintAppInstallationToken(owner, repo, env))
+  if (!token) {
     return undefined
   }
   return { owner, repo, headSha, token }
@@ -217,13 +313,12 @@ export async function reportSkip(
     )
   }
 
-  const target = getCheckRunTarget(env)
+  const target = await resolveCheckRunTarget(env)
   if (!target) {
     console.warn(
-      `Warning: ${GITHUB_CHECKS_TOKEN_VAR}, CIRCLE_PROJECT_USERNAME, CIRCLE_PROJECT_REPONAME ` +
-        'or CIRCLE_SHA1 is not set, skipping GitHub check run creation. Provide a GitHub App ' +
-        'installation token or fine-grained PAT with checks: write permission to publish a ' +
-        '"skipped" check run for skipped workflows.',
+      `Warning: no GitHub credentials (${GITHUB_CHECKS_TOKEN_VAR}, or ` +
+        `${GITHUB_CHECKS_APP_ID_VAR} with ${GITHUB_CHECKS_APP_PRIVATE_KEY_VAR}) or the CircleCI ` +
+        'project environment variables are not set, skipping GitHub check run creation.',
     )
     return
   }


### PR DESCRIPTION
## What
When `GITHUB_CHECKS_APP_ID` + `GITHUB_CHECKS_APP_PRIVATE_KEY` are set (and `GITHUB_CHECKS_TOKEN` is not), circletron signs an app JWT, resolves the repo installation, and mints a short-lived installation token — so skipped workflows are reported as **proper check runs with conclusion `skipped`**, the actual goal of `skip: check-runs` mode.

## Why
PATs cannot use the Checks API, so 3.0.14's commit-status fallback shows skips as generic green checks. Only a GitHub App token produces the real `skipped` conclusion in the checks UI. The org's fine-grained PATs cannot grant `Checks`, so app-token minting inside circletron is the practical path (no extra CI scripting for consumers).

Credential precedence: `GITHUB_CHECKS_TOKEN` → App credentials → none (fallback chain unchanged: check run → commit status → skip workflow). Private key accepted as raw PEM (real or escaped newlines) or base64.

## Validation
- `npm run validate` green (28 tests; new specs for `buildAppJwt`, `mintAppInstallationToken`, `resolveCheckRunTarget`; JWT signature verified against a generated keypair).
- Image built, JWT construction smoke-tested inside it; pushed as `ghcr.io/empathycom/circletron:3.0.15`.
- End-to-end validation on empathy-monorepo PR #18721 pending the org GitHub App credentials.

---
Conversation: https://app.warp.dev/conversation/a5db2c46-de94-4a00-b4d7-a5a24904cd91

Co-Authored-By: Oz <oz-agent@warp.dev>